### PR TITLE
「lsコマンドを作る2」の課題である-aオプションが使えるlsコマンドを実装

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -30,7 +30,7 @@ def output(filenames)
     else
       NUMBER_OF_COL_MAX
     end
-  # NOTE: OS標準のlsコマンドは横並びではなく縦並びで出力される
+  # NOTE: OS標準のlsコマンドは横並びではなく縦並びで出力される(転置して出力される)
   # NOTE: filenames_tableの要素は行と列が出力したい形(縦並び)とは逆で保存されている
   filenames_table = filenames.each_slice(number_of_row).to_a
   widths = filenames_table.map { |col| col.map(&:size).max + SPACE_WIDTH }

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -30,16 +30,16 @@ def output(filenames)
     else
       NUMBER_OF_COL_MAX
     end
-  
-  # NOTE: filenames_tableの要素は行と列が出力したい形とは逆で保存されている
+  # NOTE: OS標準のlsコマンドは横並びではなく縦並びで出力される
+  # NOTE: filenames_tableの要素は行と列が出力したい形(縦並び)とは逆で保存されている
   filenames_table = filenames.each_slice(number_of_row).to_a
   widths = filenames_table.map { |col| col.map(&:size).max + SPACE_WIDTH }
 
   number_of_row.times do |row_index|
     number_of_col.times do |col_index|
       # filenames_tableの行と列が逆で保存されているので、col_indexとrow_indexを入れ替えて出力させている
-      target_filename = filenames_table[col_index][row_index]
-      print target_filename.ljust(widths[col_index]) unless target_filename.nil?
+      current_filename = filenames_table[col_index][row_index]
+      print current_filename.ljust(widths[col_index]) unless current_filename.nil?
     end
     print "\n"
   end
@@ -47,5 +47,5 @@ end
 
 option_params = search_option
 target_path = ARGV[0] || './'
-filenames = get_filenames(target_path, option_params) 
+filenames = get_filenames(target_path, option_params)
 output(filenames) unless filenames.empty?

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -39,7 +39,7 @@ def output(filenames)
   end
 end
 
-option = search_option
+option_params = search_option
 target_path = ARGV[0] || './'
-filenames = get_filenames(target_path, option)
+filenames = get_filenames(target_path, option_params)
 output(filenames)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -11,7 +11,7 @@ def search_option(argv)
   options = {}
   opt.on('-a') { |v| options[:a] = v }
   file_paths = opt.parse(argv)
-  retrun options, file_paths
+  [options, file_paths]
 end
 
 def get_filenames(target_path, options)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -11,15 +11,12 @@ def search_option(argv)
   options = {}
   opt.on('-a') { |v| options[:a] = v }
   file_paths = opt.parse(argv)
-  return options, file_paths
+  retrun options, file_paths
 end
 
 def get_filenames(target_path, options)
-  if options[:a]
-    Dir.glob('*', File::FNM_DOTMATCH, base: target_path, sort: true)
-  else
-    Dir.glob('*', base: target_path, sort: true)
-  end
+  dotmatch_flag = options[:a] ? File::FNM_DOTMATCH : 0
+  Dir.glob('*', dotmatch_flag, base: target_path)
 end
 
 def output(filenames)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -9,7 +9,7 @@ SPACE_WIDTH = 2
 def search_option
   opt = OptionParser.new
   params = {}
-  opt.on('-a') {|v| params[:a] = v }
+  opt.on('-a') { |v| params[:a] = v }
   opt.parse!(ARGV)
   params
 end
@@ -27,12 +27,12 @@ def output(filenames)
   # NOTE: filenames_tableの要素は行と列が出力したい形とは逆で保存されている
   filenames_table = filenames.each_slice(number_of_row).to_a
 
-  widths = filenames_table.map { |filenames| filenames.map(&:size).max + SPACE_WIDTH }
+  widths = filenames_table.map { |col| col.map(&:size).max + SPACE_WIDTH }
 
   number_of_row.times do |row_index|
     NUMBER_OF_COL.times do |col_index|
       # filenames_tableの行と列が逆で保存されているので、col_indexとrow_indexを入れ替えて出力させている
-      target_filename = filenames_table[col_index][row_index] 
+      target_filename = filenames_table[col_index][row_index]
       print target_filename.ljust(widths[col_index]) unless target_filename.nil?
     end
     print "\n"

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -41,7 +41,7 @@ def output(filenames)
     number_of_col.times do |col_index|
       # filenames_tableの行と列が逆で保存されているので、col_indexとrow_indexを入れ替えて出力させている
       target_filename = filenames_table[col_index][row_index]
-      print target_filename.ljust(widths[col_index]) unless target_filename.nil?
+      print target_filename&.ljust(widths[col_index])
     end
     print "\n"
   end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -47,7 +47,7 @@ def output(filenames)
   end
 end
 
-option_params, arguments_without_options = search_option(ARGV)
-target_path = arguments_without_options[0] || './'
+option_params, file_paths = search_option(ARGV)
+target_path = file_paths[0] || './'
 filenames = get_filenames(target_path, option_params)
 output(filenames)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,11 +1,22 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'optparse'
+
 NUMBER_OF_COL = 3
 SPACE_WIDTH = 2
 
 def get_filenames(target_path)
-  Dir.glob('*', base: target_path)
+  opt = OptionParser.new
+  params = {}
+  opt.on('-a') {|v| params[:a] = v }
+  opt.parse(ARGV)
+
+  if params[:a]
+    Dir.entries(target_path).sort
+  else
+    Dir.glob('*', base: target_path)
+  end
 end
 
 def output(filenames)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -42,6 +42,6 @@ end
 
 # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
 options, directory_paths = parse_options(ARGV)
-target_directory_path = directory_paths[0] || './'
-file_names = fetch_file_names(target_directory_path, options)
+directory_path = directory_paths[0] || './'
+file_names = fetch_file_names(directory_path, options)
 output(file_names)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -8,10 +8,10 @@ SPACE_WIDTH = 2
 
 def search_option(argv)
   opt = OptionParser.new
-  params = {}
-  opt.on('-a') { |v| params[:a] = v }
-  opt.parse!(argv)
-  params
+  option_params = {}
+  opt.on('-a') { |v| option_params[:a] = v }
+  arguments_without_options = opt.parse(argv)
+  return option_params, arguments_without_options
 end
 
 def get_filenames(target_path, params)
@@ -47,7 +47,7 @@ def output(filenames)
   end
 end
 
-option_params = search_option(ARGV)
-target_path = ARGV[0] || './'
+option_params, arguments_without_options = search_option(ARGV)
+target_path = arguments_without_options[0] || './'
 filenames = get_filenames(target_path, option_params)
 output(filenames)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -3,7 +3,7 @@
 
 require 'optparse'
 
-NUMBER_OF_COL = 3
+NUMBER_OF_COL_MAX = 3
 SPACE_WIDTH = 2
 
 def search_option
@@ -23,14 +23,20 @@ def get_filenames(target_path, params)
 end
 
 def output(filenames)
-  number_of_row = ((filenames.size - 1) / NUMBER_OF_COL) + 1
+  number_of_row = ((filenames.size - 1) / NUMBER_OF_COL_MAX) + 1
+  number_of_col =
+    if filenames.size < NUMBER_OF_COL_MAX
+      filenames.size
+    else
+      NUMBER_OF_COL_MAX
+    end
+  
   # NOTE: filenames_tableの要素は行と列が出力したい形とは逆で保存されている
   filenames_table = filenames.each_slice(number_of_row).to_a
-
   widths = filenames_table.map { |col| col.map(&:size).max + SPACE_WIDTH }
 
   number_of_row.times do |row_index|
-    NUMBER_OF_COL.times do |col_index|
+    number_of_col.times do |col_index|
       # filenames_tableの行と列が逆で保存されているので、col_indexとrow_indexを入れ替えて出力させている
       target_filename = filenames_table[col_index][row_index]
       print target_filename.ljust(widths[col_index]) unless target_filename.nil?
@@ -41,5 +47,5 @@ end
 
 option_params = search_option
 target_path = ARGV[0] || './'
-filenames = get_filenames(target_path, option_params)
-output(filenames)
+filenames = get_filenames(target_path, option_params) 
+output(filenames) unless filenames.empty?

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -26,12 +26,8 @@ def output(filenames)
   return if filenames.empty?
 
   number_of_row = ((filenames.size - 1) / NUMBER_OF_COL_MAX) + 1
-  number_of_col =
-    if filenames.size < NUMBER_OF_COL_MAX
-      filenames.size
-    else
-      NUMBER_OF_COL_MAX
-    end
+  number_of_col = filenames.size < NUMBER_OF_COL_MAX ? filenames.size : NUMBER_OF_COL_MAX
+  
   # NOTE: OS標準のlsコマンドは横並びではなく縦並びで出力される(転置して出力される)
   # NOTE: filenames_tableの要素は行と列が出力したい形(縦並び)とは逆で保存されている
   filenames_table = filenames.each_slice(number_of_row).to_a

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -8,14 +8,14 @@ SPACE_WIDTH = 2
 
 def search_option(argv)
   opt = OptionParser.new
-  params = {}
-  opt.on('-a') { |v| params[:a] = v }
+  options = {}
+  opt.on('-a') { |v| options[:a] = v }
   file_paths = opt.parse(argv)
-  return params, file_paths
+  return options, file_paths
 end
 
-def get_filenames(target_path, params)
-  if params[:a]
+def get_filenames(target_path, options)
+  if options[:a]
     Dir.glob('*', File::FNM_DOTMATCH, base: target_path, sort: true)
   else
     Dir.glob('*', base: target_path, sort: true)
@@ -27,7 +27,7 @@ def output(filenames)
 
   number_of_row = ((filenames.size - 1) / NUMBER_OF_COL_MAX) + 1
   number_of_col = filenames.size < NUMBER_OF_COL_MAX ? filenames.size : NUMBER_OF_COL_MAX
-  
+
   # NOTE: OS標準のlsコマンドは横並びではなく縦並びで出力される(転置して出力される)
   # NOTE: filenames_tableの要素は行と列が出力したい形(縦並び)とは逆で保存されている
   filenames_table = filenames.each_slice(number_of_row).to_a
@@ -43,7 +43,7 @@ def output(filenames)
   end
 end
 
-params, file_paths = search_option(ARGV)
+options, file_paths = search_option(ARGV)
 target_path = file_paths[0] || './'
-filenames = get_filenames(target_path, params)
+filenames = get_filenames(target_path, options)
 output(filenames)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -23,6 +23,8 @@ def get_filenames(target_path, params)
 end
 
 def output(filenames)
+  return if filenames.empty?
+
   number_of_row = ((filenames.size - 1) / NUMBER_OF_COL_MAX) + 1
   number_of_col =
     if filenames.size < NUMBER_OF_COL_MAX
@@ -48,4 +50,4 @@ end
 option_params = search_option(ARGV)
 target_path = ARGV[0] || './'
 filenames = get_filenames(target_path, option_params)
-output(filenames) unless filenames.empty?
+output(filenames)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -9,9 +9,9 @@ SPACE_WIDTH = 2
 def search_option(argv)
   opt = OptionParser.new
   option_params = {}
-  opt.on('-a') { |v| option_params[:a] = v }
-  arguments_without_options = opt.parse(argv)
-  return option_params, arguments_without_options
+  opt.on('-a') { |v| params[:a] = v }
+  file_paths = opt.parse(argv)
+  return params, file_paths
 end
 
 def get_filenames(target_path, params)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -3,44 +3,45 @@
 
 require 'optparse'
 
-NUMBER_OF_COL_MAX = 3
+MAX_COL_COUNT = 3
 SPACE_WIDTH = 2
 
-def search_option(argv)
+def parse_options(argv)
   opt = OptionParser.new
   options = {}
   opt.on('-a') { |v| options[:a] = v }
-  file_paths = opt.parse(argv)
-  [options, file_paths]
+  directory_paths = opt.parse(argv)
+  [options, directory_paths]
 end
 
-def get_filenames(target_path, options)
+def fetch_file_names(target_directory_path, options)
   dotmatch_flag = options[:a] ? File::FNM_DOTMATCH : 0
-  Dir.glob('*', dotmatch_flag, base: target_path)
+  Dir.glob('*', dotmatch_flag, base: target_directory_path)
 end
 
-def output(filenames)
-  return if filenames.empty?
+def output(file_names)
+  return if file_names.empty?
 
-  number_of_row = ((filenames.size - 1) / NUMBER_OF_COL_MAX) + 1
-  number_of_col = [filenames.size, NUMBER_OF_COL_MAX].min
+  row_count = ((file_names.size - 1) / MAX_COL_COUNT) + 1
+  col_count = [file_names.size, MAX_COL_COUNT].min
 
   # NOTE: OS標準のlsコマンドは横並びではなく縦並びで出力される(転置して出力される)
-  # NOTE: filenames_tableの要素は行と列が出力したい形(縦並び)とは逆で保存されている
-  filenames_table = filenames.each_slice(number_of_row).to_a
-  widths = filenames_table.map { |col| col.map(&:size).max + SPACE_WIDTH }
+  # NOTE: file_names_tableの要素は行と列が出力したい形(縦並び)とは逆で保存されている
+  file_names_table = file_names.each_slice(row_count).to_a
+  widths = file_names_table.map { |col| col.map(&:size).max + SPACE_WIDTH }
 
-  number_of_row.times do |row_index|
-    number_of_col.times do |col_index|
-      # filenames_tableの行と列が逆で保存されているので、col_indexとrow_indexを入れ替えて出力させている
-      target_filename = filenames_table[col_index][row_index]
-      print target_filename&.ljust(widths[col_index])
+  row_count.times do |row_index|
+    col_count.times do |col_index|
+      # file_names_tableの行と列が逆で保存されているので、col_indexとrow_indexを入れ替えて出力させている
+      target_file_name = file_names_table[col_index][row_index]
+      print target_file_name&.ljust(widths[col_index])
     end
     print "\n"
   end
 end
 
-options, file_paths = search_option(ARGV)
-target_path = file_paths[0] || './'
-filenames = get_filenames(target_path, options)
-output(filenames)
+# directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
+options, directory_paths = parse_options(ARGV)
+target_directory_path = directory_paths[0] || './'
+file_names = fetch_file_names(target_directory_path, options)
+output(file_names)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -47,7 +47,7 @@ def output(filenames)
   end
 end
 
-option_params, file_paths = search_option(ARGV)
+params, file_paths = search_option(ARGV)
 target_path = file_paths[0] || './'
-filenames = get_filenames(target_path, option_params)
+filenames = get_filenames(target_path, params)
 output(filenames)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -6,11 +6,11 @@ require 'optparse'
 NUMBER_OF_COL_MAX = 3
 SPACE_WIDTH = 2
 
-def search_option
+def search_option(argv)
   opt = OptionParser.new
   params = {}
   opt.on('-a') { |v| params[:a] = v }
-  opt.parse!(ARGV)
+  opt.parse!(argv)
   params
 end
 
@@ -45,7 +45,7 @@ def output(filenames)
   end
 end
 
-option_params = search_option
+option_params = search_option(ARGV)
 target_path = ARGV[0] || './'
 filenames = get_filenames(target_path, option_params)
 output(filenames) unless filenames.empty?

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -16,9 +16,9 @@ end
 
 def get_filenames(target_path, params)
   if params[:a]
-    Dir.entries(target_path).sort
+    Dir.glob('*', File::FNM_DOTMATCH, base: target_path, sort: true)
   else
-    Dir.glob('*', base: target_path)
+    Dir.glob('*', base: target_path, sort: true)
   end
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -6,12 +6,15 @@ require 'optparse'
 NUMBER_OF_COL = 3
 SPACE_WIDTH = 2
 
-def get_filenames(target_path)
+def search_option
   opt = OptionParser.new
   params = {}
   opt.on('-a') {|v| params[:a] = v }
-  opt.parse(ARGV)
+  opt.parse!(ARGV)
+  params
+end
 
+def get_filenames(target_path, params)
   if params[:a]
     Dir.entries(target_path).sort
   else
@@ -36,6 +39,7 @@ def output(filenames)
   end
 end
 
+option = search_option
 target_path = ARGV[0] || './'
-filenames = get_filenames(target_path)
+filenames = get_filenames(target_path, option)
 output(filenames)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -8,7 +8,7 @@ SPACE_WIDTH = 2
 
 def search_option(argv)
   opt = OptionParser.new
-  option_params = {}
+  params = {}
   opt.on('-a') { |v| params[:a] = v }
   file_paths = opt.parse(argv)
   return params, file_paths

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -23,7 +23,7 @@ def output(filenames)
   return if filenames.empty?
 
   number_of_row = ((filenames.size - 1) / NUMBER_OF_COL_MAX) + 1
-  number_of_col = filenames.size < NUMBER_OF_COL_MAX ? filenames.size : NUMBER_OF_COL_MAX
+  number_of_col = [filenames.size, NUMBER_OF_COL_MAX].min
 
   # NOTE: OS標準のlsコマンドは横並びではなく縦並びで出力される(転置して出力される)
   # NOTE: filenames_tableの要素は行と列が出力したい形(縦並び)とは逆で保存されている

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -38,8 +38,8 @@ def output(filenames)
   number_of_row.times do |row_index|
     number_of_col.times do |col_index|
       # filenames_tableの行と列が逆で保存されているので、col_indexとrow_indexを入れ替えて出力させている
-      current_filename = filenames_table[col_index][row_index]
-      print current_filename.ljust(widths[col_index]) unless current_filename.nil?
+      target_filename = filenames_table[col_index][row_index]
+      print target_filename.ljust(widths[col_index]) unless target_filename.nil?
     end
     print "\n"
   end


### PR DESCRIPTION
[lsコマンドを作る2 \| FBC](https://bootcamp.fjord.jp/practices/222)の課題として、lsコマンドに-aオプションを実装しました。

コードの中での補足や気になる点はコメントで記載しています。

レビューをお願い致します。


## 実行結果
※提出フォームでも記載していますが、PRだけ見られる方もいるので、実行結果をdescriptionにも記載します。

### 作成したlsコマンドの実行結果


![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBOHdqQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--db56e43d7b925743816c44a22a78500f364b3b67/image.png)



上から順に
1. オプションなし、ディレクトリの指定なし
2.  `-a`オプション有、ディレクトリ指定なし
3.  オプションなし、ディレクトリ指定有
4. `-a`オプション有、ディレクトリ指定有

という条件で実行しています。

### OS標準のlsコマンドの実行結果

![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBODBqQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--973c777509d04d44f3b062d3ad2db54f13ddd942/image.png)




同じく
1. オプションなし、ディレクトリの指定なし
2.  `-a`オプション有、ディレクトリ指定なし
3.  オプションなし、ディレクトリ指定有
4. `-a`オプション有、ディレクトリ指定有

という条件で実行しています。

### その他補足
- 平仮名や漢字にすると、左揃えでなくなる問題にはまだ手をつけていません
- ディレクトリ名は指定できますが、ファイル名を指定することはまだできません。(今後どこかのタイミングで対応したいとは思っています。)
- lsコマンドにaliasを設定しており、`ls`と打つとディレクトリ名は青色になるなど、標準とは異なる表示がされてしまうので、`\ls`という形で実行しています。
- OS標準のlsコマンドとはソートのルールが違うようで、出力順は異なっています