### PR TITLE
「lsコマンドを作る3」の課題としてls.rbに-rオプションを実装

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -10,13 +10,15 @@ def parse_options(argv)
   opt = OptionParser.new
   options = {}
   opt.on('-a') { |v| options[:a] = v }
+  opt.on('-r') { |v| options[:r] = v }
   directory_paths = opt.parse(argv)
   [options, directory_paths]
 end
 
 def fetch_file_names(target_directory_path, options)
   dotmatch_flag = options[:a] ? File::FNM_DOTMATCH : 0
-  Dir.glob('*', dotmatch_flag, base: target_directory_path)
+  file_names = Dir.glob('*', dotmatch_flag, base: target_directory_path)
+  options[:r] ? file_names.reverse : file_names
 end
 
 def output(file_names)


### PR DESCRIPTION
[lsコマンドを作る3 \| FBC](https://bootcamp.fjord.jp/practices/223)の課題として、lsコマンドに-rオプションを実装しました。

レビューお願い致します。


## 実行結果
※提出フォームでも記載していますが、PRだけ見られる方もいるので、実行結果をdescriptionにも記載します。

### 作成したlsコマンドの実行結果

![image](https://github.com/cellotak/ruby-practices/assets/65953037/554505fd-a930-491d-99bf-029c6f0bca42)


上から順に
1. オプションなし
2.  `-r`オプション有
3. `-a`オプション有
4. `-r`オプションと`-a`オプション有 (個別に指定)
5. `-r`オプションと`-a`オプション有 (まとめて指定)
という条件で実行しています。


### OS標準のlsコマンドの実行結果

![image](https://github.com/cellotak/ruby-practices/assets/65953037/addd2bbb-2ab2-4b31-afe7-1f8b2e0282bd)


同じく上から順に
1. オプションなし
2.  `-r`オプション有
3. `-a`オプション有
4. `-r`オプションと`-a`オプション有 (個別に指定)
5. `-r`オプションと`-a`オプション有 (まとめて指定)
という条件で実行しています。


### 補足
- 「-aオプションは実装しなくてよいです。」とありましたが、特に変更なしで-aオプションとの共存ができているので、そのまま残しています。
- 平仮名や漢字にすると、左揃えでなくなる問題にはまだ手をつけていません
- ディレクトリ名は指定できますが、ファイル名の指定や複数ディレクトリの指定には対応していません。(どこかのタイミングで対応したいとは思っています。)
- lsコマンドにaliasを設定しており、`ls`と打つとディレクトリ名は青色になるなど、標準とは異なる表示がされてしまうので、`\ls`という形で実行しています。
- OS標準のlsコマンドとはソートのルールが違うようで、出力順は異なっています。