### PR TITLE
「lsコマンドを作る4」の課題としてlsコマンドに-l オプションを追加

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -18,6 +18,11 @@ end
 def fetch_file_names(target_directory_path, options)
   dotmatch_flag = options[:a] ? File::FNM_DOTMATCH : 0
   file_names = Dir.glob('*', dotmatch_flag, base: target_directory_path)
+
+  stats = file_names.map{|file_name| File.stat("#{target_directory_path}/#{file_name}")}
+  
+  stats.each {|stat| puts  "#{stat.ctime} #{stat.size}"}
+
   options[:r] ? file_names.reverse : file_names
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -46,49 +46,30 @@ end
 
 def output_long_listing_format(file_names, target_directory_path)
   block_count_total = 0
-
   details_by_file_name = {}
 
   file_names.each do |file_name|
     stat = File.stat("#{target_directory_path}/#{file_name}")
-
-    details = []
-    details << convert_stat_mode_to_str(stat.mode).to_s
-    details << stat.nlink.to_s
-    details << Etc.getpwuid(stat.uid).name.to_s
-    details << Etc.getgrgid(stat.gid).name.to_s
-    details << stat.size.to_s
-    details << stat.ctime.strftime('%b').to_s
-    details << stat.ctime.strftime('%-d').to_s
-    details << stat.ctime.strftime('%H:%M').to_s
-    details << file_name.to_s
-
     block_count_total += stat.blocks
-
-    details_by_file_name[file_name.to_s] = details
+    details = convert_stat_to_details(stat)
+    details_by_file_name[file_name] = details
   end
 
-  details_size = details_by_file_name[file_names[0]].size
-
-  max_widths_by_detail = []
-  details_size.times do |index|
-    detail_widths_by_file_name = details_by_file_name.map { |_file_name, details| details[index].length }
-    max_widths_by_detail << detail_widths_by_file_name.max
-  end
+  max_widths_by_detail = fetch_max_widths_by_detail(details_by_file_name)
 
   puts "total #{block_count_total}"
 
   file_names.each do |file_name|
-    details_size.times do |index|
-      target_detail = details_by_file_name[file_name.to_s][index].to_s
-      if /^\d+$/.match?(target_detail)
-        print target_detail.rjust(max_widths_by_detail[index])
+    details = details_by_file_name[file_name]
+    details.each_with_index do |detail, index|
+      if /^\d+$/.match?(detail)
+        print detail.rjust(max_widths_by_detail[index])
       else
-        print target_detail.ljust(max_widths_by_detail[index])
+        print detail.ljust(max_widths_by_detail[index])
       end
       print ' '
     end
-    print "\n"
+    puts file_name
   end
 end
 
@@ -109,6 +90,28 @@ def output_default_format(file_names)
     end
     print "\n"
   end
+end
+
+def convert_stat_to_details(stat)
+  details = []
+  details << convert_stat_mode_to_str(stat.mode).to_s
+  details << stat.nlink.to_s
+  details << Etc.getpwuid(stat.uid).name.to_s
+  details << Etc.getgrgid(stat.gid).name.to_s
+  details << stat.size.to_s
+  details << stat.ctime.strftime('%b').to_s
+  details << stat.ctime.strftime('%-d').to_s
+  details << stat.ctime.strftime('%H:%M').to_s
+end
+
+def fetch_max_widths_by_detail(details_by_file_name)
+  max_widths_by_detail = []
+  details_size = details_by_file_name.values[0].length
+  details_size.times do |index|
+    detail_widths_by_file_name = details_by_file_name.map { |_file_name, details| details[index].length }
+    max_widths_by_detail << detail_widths_by_file_name.max
+  end
+  max_widths_by_detail
 end
 
 def convert_stat_mode_to_str(stat_mode)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -9,7 +9,6 @@ SPACE_WIDTH = 2
 
 FILE_TYPE_LIST = { '01' => 'p', '02' => 'c', '04' => 'd', '06' => 'b', '10' => '-', '12' => 'l', '14' => 's' }.freeze
 
-
 def main
   options, directory_paths = parse_options(ARGV)
   # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
@@ -56,17 +55,16 @@ def output_long_listing_format(file_names, target_directory_path)
     details_by_file_name[file_name] = details
   end
 
-  max_widths_by_detail = get_max_widths_by_detail(details_by_file_name)
-
   puts "total #{block_count_total}"
 
   file_names.each do |file_name|
     details = details_by_file_name[file_name]
     details.each_with_index do |detail, index|
+      width = get_max_width_by_detail(details_by_file_name, index)
       if /^\d+$/.match?(detail)
-        print detail.rjust(max_widths_by_detail[index])
+        print detail.rjust(width)
       else
-        print detail.ljust(max_widths_by_detail[index])
+        print detail.ljust(width)
       end
       print ' '
     end
@@ -103,14 +101,9 @@ def convert_stat_to_details(stat)
   details << stat.ctime.strftime('%b %e %H:%M')
 end
 
-def get_max_widths_by_detail(details_by_file_name)
-  max_widths_by_detail = []
-  details_size = details_by_file_name.values[0].length
-  details_size.times do |index|
-    detail_widths_by_file_name = details_by_file_name.map { |_file_name, details| details[index].length }
-    max_widths_by_detail << detail_widths_by_file_name.max
-  end
-  max_widths_by_detail
+def get_max_width_by_detail(details_by_file_name, index)
+  detail_widths_by_file_name = details_by_file_name.map { |_file_name, details| details[index].length }
+  detail_widths_by_file_name.max
 end
 
 def convert_stat_mode_to_str(stat_mode)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -7,6 +7,8 @@ require 'etc'
 MAX_COL_COUNT = 3
 SPACE_WIDTH = 2
 
+FILE_TYPE_LIST = {"01"=>"p", "02"=>"c", "04"=>"d", "06"=>"b", "10"=>"-", "12"=>"l", "14"=>"s"}
+
 def parse_options(argv)
   opt = OptionParser.new
   options = {}
@@ -56,8 +58,12 @@ end
 def output_long_listing_format(target_directory_path, file_names, options)
   file_names.each do |file_name| 
     stat = File.stat("#{target_directory_path}/#{file_name}")
+    file_type_num = format("%06o",stat.mode).slice(0..1) 
+    file_type_str = FILE_TYPE_LIST[file_type_num]
+
     detail_str =
-      "#{stat.mode} "\
+      "#{file_type_str} "\
+      "#{format("%06o",stat.mode)} "\
       "#{stat.nlink} "\
       "#{Etc.getpwuid(stat.uid).name} "\
       "#{Etc.getgrgid(stat.gid).name} "\

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -46,20 +46,48 @@ end
 
 def output_long_listing_format(file_names, target_directory_path)
   block_count_total = 0
+
+  details_list = {}
+  details_size = 0
+
   file_names.each do |file_name|
     stat = File.stat("#{target_directory_path}/#{file_name}")
+    details = []
+    details << "#{convert_stat_mode_to_str(stat.mode)}"
+    details << "#{stat.nlink}"
+    details << "#{Etc.getpwuid(stat.uid).name}"
+    details << "#{Etc.getgrgid(stat.gid).name}"
+    details << "#{stat.size}"
+    details << "#{stat.ctime.strftime('%b')}"
+    details << "#{stat.ctime.strftime('%-d')}"
+    details << "#{stat.ctime.strftime('%H:%M')}"
+    details << "#{file_name}"
     block_count_total += stat.blocks
-    detail_str =
-      "#{convert_stat_mode_to_str(stat.mode)} "\
-      "#{stat.nlink} "\
-      "#{Etc.getpwuid(stat.uid).name} "\
-      "#{Etc.getgrgid(stat.gid).name} "\
-      "#{stat.size} "\
-      "#{stat.ctime.strftime('%b %-d %H:%M')} "\
-      "#{file_name}"
-    puts detail_str
+    details_size = details.size
+    details_list["#{file_name}"] = details
   end
+
+  widths = []
+  details_size.times do |index|
+    lengths = details_list.map{|file_name, details| details[index].length}
+    widths << lengths.max + 1
+  end
+  p widths
+
   puts "total #{block_count_total}"
+
+
+  file_names.each do |file_name|
+    details_size.times do |index| 
+      if  /^\d+$/.match("#{details_list["#{file_name}"][index]}")
+        print "#{details_list["#{file_name}"][index]} ".rjust(widths[index])
+      else
+        print "#{details_list["#{file_name}"][index]}".ljust(widths[index])
+      end
+    end
+    print "\n"
+  end
+
 end
 
 def output_default_format(file_names)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -27,27 +27,27 @@ def parse_options(argv)
   [options, directory_paths]
 end
 
-def fetch_file_names(target_directory_path, options)
+def fetch_file_names(directory_path, options)
   dotmatch_flag = options[:a] ? File::FNM_DOTMATCH : 0
-  file_names = Dir.glob('*', dotmatch_flag, base: target_directory_path)
+  file_names = Dir.glob('*', dotmatch_flag, base: directory_path)
 
   options[:r] ? file_names.reverse : file_names
 end
 
-def output(file_names, target_directory_path, options)
+def output(file_names, directory_path, options)
   return if file_names.empty?
 
   if options[:l]
-    output_long_listing_format(file_names, target_directory_path)
+    output_long_listing_format(file_names, directory_path)
   else
     output_default_format(file_names)
   end
 end
 
-def output_long_listing_format(file_names, target_directory_path)
-  puts "total #{calc_block_count_total(file_names, target_directory_path)}"
+def output_long_listing_format(file_names, directory_path)
+  puts "total #{calc_block_count_total(file_names, directory_path)}"
 
-  details_by_file_name = build_details_by_file_name(file_names, target_directory_path)
+  details_by_file_name = build_details_by_file_name(file_names, directory_path)
 
   file_names.each do |file_name|
     details = details_by_file_name[file_name]
@@ -66,17 +66,17 @@ def output_long_listing_format(file_names, target_directory_path)
   end
 end
 
-def calc_block_count_total(file_names, target_directory_path)
+def calc_block_count_total(file_names, directory_path)
   file_names.map do |file_name| 
-    file_path = "#{target_directory_path}/#{file_name}"
+    file_path = "#{directory_path}/#{file_name}"
     File.stat(file_path).blocks
   end.sum
 end
 
-def build_details_by_file_name(file_names, target_directory_path)
+def build_details_by_file_name(file_names, directory_path)
   details_by_file_name = {}
   file_names.each do |file_name|
-    stat = File.stat("#{target_directory_path}/#{file_name}")
+    stat = File.stat("#{directory_path}/#{file_name}")
     details = convert_stat_to_details(stat)
     details_by_file_name[file_name] = details
   end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -82,18 +82,17 @@ def convert_stat_mode_to_str(stat_mode)
 end
 
 def convert_permission_num_to_str(permission_num)
-  permission_str_array = []
-  permission_num.chars.each do |nc|
-    n = nc.to_i
-    permission_array = Array.new(3, '-')
+  permission_num_digits = permission_num.chars.map(&:to_i)
+  partial_permission_strings = permission_num_digits.map do |digit|
+    partial_permission_string = '-' * 3
 
-    permission_array[0] = 'r' if n / 4 == 1
-    permission_array[1] = 'w' if (n / 2).odd?
-    permission_array[2] = 'x' if n.odd?
+    partial_permission_string[0] = 'r' if digit / 4 == 1
+    partial_permission_string[1] = 'w' if (digit / 2).odd?
+    partial_permission_string[2] = 'x' if digit.odd?
 
-    permission_str_array += permission_array
+    partial_permission_string
   end
-  permission_str_array.join
+  partial_permission_strings.join
 end
 
 # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'optparse'
+require 'etc'
 
 MAX_COL_COUNT = 3
 SPACE_WIDTH = 2
@@ -55,11 +56,11 @@ end
 def output_long_listing_format(target_directory_path, file_names, options)
   file_names.each do |file_name| 
     stat = File.stat("#{target_directory_path}/#{file_name}")
-    detail_str = 
+    detail_str =
       "#{stat.mode} "\
       "#{stat.nlink} "\
-      "#{stat.uid} "\
-      "#{stat.gid} "\
+      "#{Etc.getpwuid(stat.uid).name} "\
+      "#{Etc.getgrgid(stat.gid).name} "\
       "#{stat.size} "\
       "#{stat.ctime} "\
       "#{file_name}"

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -65,7 +65,7 @@ def output_long_listing_format(target_directory_path, file_names, options)
       "#{Etc.getpwuid(stat.uid).name} "\
       "#{Etc.getgrgid(stat.gid).name} "\
       "#{stat.size} "\
-      "#{stat.ctime} "\
+      "#{stat.ctime.strftime("%b %-d %H:%M")} "\
       "#{file_name}"
     puts detail_str
   end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -9,11 +9,12 @@ SPACE_WIDTH = 2
 
 FILE_TYPE_LIST = { '01' => 'p', '02' => 'c', '04' => 'd', '06' => 'b', '10' => '-', '12' => 'l', '14' => 's' }.freeze
 
-# directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
+
 def main
   options, directory_paths = parse_options(ARGV)
-  target_directory_path = directory_paths[0] || './'
-  file_names = fetch_file_names(target_directory_path, options)
+  # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
+  directory_path = directory_paths[0] || './'
+  file_names = fetch_file_names(directory_path, options)
   output(file_names, target_directory_path, options)
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -67,11 +67,10 @@ def output_long_listing_format(file_names, target_directory_path)
 end
 
 def calc_block_count_total(file_names, target_directory_path)
-  block_count_total = 0
-  file_names.each do |file_name|
-    block_count_total += File.stat("#{target_directory_path}/#{file_name}").blocks
-  end
-  block_count_total
+  file_names.map do |file_name| 
+    file_path = "#{target_directory_path}/#{file_name}"
+    File.stat(file_path).blocks
+  end.sum
 end
 
 def build_details_by_file_name(file_names, target_directory_path)
@@ -119,7 +118,7 @@ def convert_permission_code_to_str(permission_code)
   permission_octets.join
 end
 
-def calcu_max_width_by_detail(details_by_file_name, key)
+def calc_max_width_by_detail(details_by_file_name, key)
   detail_widths_by_file_name = details_by_file_name.map { |_file_name, details| details[key].length }
   detail_widths_by_file_name.max
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -24,10 +24,10 @@ def fetch_file_details(target_directory_path, options)
   if options[:l]
     file_details.each do |file_detail|
       stat = File.stat("#{target_directory_path}/#{file_detail[:name]}")
-      file_detail[:mode] = stat.mode
+      file_detail[:mode] = stat.mode # 要変換
       file_detail[:hardlink_count] = stat.nlink
-      file_detail[:owner_user] = stat.uid
-      file_detail[:owner_group] = stat.gid
+      file_detail[:owner_user] = stat.uid # 要変換
+      file_detail[:owner_group] = stat.gid # 要変換
       file_detail[:size] = stat.size
       file_detail[:ctime] = stat.ctime
     end
@@ -41,14 +41,15 @@ def output(file_details, options)
 
   if options[:l]
     file_details.each do |file_detail|
-      print file_detail[:mode] # 要変換
-      print file_detail[:hardlink_count]
-      print file_detail[:owner_user] # 要変換
-      print file_detail[:owner_group] # 要変換
-      print file_detail[:size]
-      print file_detail[:ctime]
-      print file_detail[:name]
-      puts
+      detail_str = 
+        "#{file_detail[:mode]} "\
+        "#{file_detail[:hardlink_count]} "\
+        "#{file_detail[:owner_user]} "\
+        "#{file_detail[:owner_group]} "\
+        "#{file_detail[:size]} "\
+        "#{file_detail[:ctime]} "\
+        "#{file_detail[:name]}"
+      puts detail_str
     end
 
   else

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -51,13 +51,14 @@ def output_long_listing_format(file_names, target_directory_path)
 
   file_names.each do |file_name|
     details = details_by_file_name[file_name]
+    details_output_order = %i[stat_mode nlink username groupname size ctime]
 
-    details.each_with_index do |detail, index|
-      width = get_max_width_by_detail(details_by_file_name, index)
-      if /^\d+$/.match?(detail)
-        print detail.rjust(width)
+    details_output_order.each do |key|
+      width = get_max_width_by_detail(details_by_file_name, key)
+      if /^\d+$/.match?(details[key])
+        print details[key].rjust(width)
       else
-        print detail.ljust(width)
+        print details[key].ljust(width)
       end
       print ' '
     end
@@ -84,13 +85,14 @@ def get_details_by_file_name(file_names, target_directory_path)
 end
 
 def convert_stat_to_details(stat)
-  details = []
-  details << convert_stat_mode_to_str(stat.mode)
-  details << stat.nlink.to_s
-  details << Etc.getpwuid(stat.uid).name
-  details << Etc.getgrgid(stat.gid).name
-  details << stat.size.to_s
-  details << stat.ctime.strftime('%b %e %H:%M')
+  details = {}
+  details[:stat_mode] = convert_stat_mode_to_str(stat.mode)
+  details[:nlink] = stat.nlink.to_s
+  details[:username] = Etc.getpwuid(stat.uid).name
+  details[:groupname] = Etc.getgrgid(stat.gid).name
+  details[:size] = stat.size.to_s
+  details[:ctime] = stat.ctime.strftime('%b %e %H:%M')
+  details
 end
 
 def convert_stat_mode_to_str(stat_mode)
@@ -117,8 +119,8 @@ def convert_permission_code_to_str(permission_code)
   permission_octets.join
 end
 
-def get_max_width_by_detail(details_by_file_name, index)
-  detail_widths_by_file_name = details_by_file_name.map { |_file_name, details| details[index].length }
+def get_max_width_by_detail(details_by_file_name, key)
+  detail_widths_by_file_name = details_by_file_name.map { |_file_name, details| details[key].length }
   detail_widths_by_file_name.max
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -44,6 +44,22 @@ def output(file_names, target_directory_path, options)
   end
 end
 
+def output_long_listing_format(file_names, target_directory_path)
+  file_names.each do |file_name|
+    stat = File.stat("#{target_directory_path}/#{file_name}")
+
+    detail_str =
+      "#{convert_stat_mode_to_str(stat.mode)} "\
+      "#{stat.nlink} "\
+      "#{Etc.getpwuid(stat.uid).name} "\
+      "#{Etc.getgrgid(stat.gid).name} "\
+      "#{stat.size} "\
+      "#{stat.ctime.strftime('%b %-d %H:%M')} "\
+      "#{file_name}"
+    puts detail_str
+  end
+end
+
 def output_default_format(file_names)
   row_count = ((file_names.size - 1) / MAX_COL_COUNT) + 1
   col_count = [file_names.size, MAX_COL_COUNT].min
@@ -60,22 +76,6 @@ def output_default_format(file_names)
       print target_file_name&.ljust(widths[col_index])
     end
     print "\n"
-  end
-end
-
-def output_long_listing_format(file_names, target_directory_path)
-  file_names.each do |file_name|
-    stat = File.stat("#{target_directory_path}/#{file_name}")
-
-    detail_str =
-      "#{convert_stat_mode_to_str(stat.mode)} "\
-      "#{stat.nlink} "\
-      "#{Etc.getpwuid(stat.uid).name} "\
-      "#{Etc.getgrgid(stat.gid).name} "\
-      "#{stat.size} "\
-      "#{stat.ctime.strftime('%b %-d %H:%M')} "\
-      "#{file_name}"
-    puts detail_str
   end
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -9,6 +9,14 @@ SPACE_WIDTH = 2
 
 FILE_TYPE_LIST = { '01' => 'p', '02' => 'c', '04' => 'd', '06' => 'b', '10' => '-', '12' => 'l', '14' => 's' }.freeze
 
+# directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
+def main
+  options, directory_paths = parse_options(ARGV)
+  target_directory_path = directory_paths[0] || './'
+  file_names = fetch_file_names(target_directory_path, options)
+  output(file_names, target_directory_path, options)
+end
+
 def parse_options(argv)
   opt = OptionParser.new
   options = {}
@@ -95,8 +103,4 @@ def convert_permission_num_to_str(permission_num)
   partial_permission_strings.join
 end
 
-# directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
-options, directory_paths = parse_options(ARGV)
-target_directory_path = directory_paths[0] || './'
-file_names = fetch_file_names(target_directory_path, options)
-output(file_names, target_directory_path, options)
+main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -9,6 +9,8 @@ SPACE_WIDTH = 2
 
 FILE_TYPE_LIST = { '01' => 'p', '02' => 'c', '04' => 'd', '06' => 'b', '10' => '-', '12' => 'l', '14' => 's' }.freeze
 
+DETAILS_OUTPUT_ORDER = %i[stat_mode nlink username groupname size ctime]
+
 def main
   options, directory_paths = parse_options(ARGV)
   # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
@@ -51,9 +53,8 @@ def output_long_listing_format(file_names, directory_path)
 
   file_names.each do |file_name|
     details = details_by_file_name[file_name]
-    details_output_order = %i[stat_mode nlink username groupname size ctime]
 
-    details_output_order.each do |key|
+    DETAILS_OUTPUT_ORDER.each do |key|
       width = calc_max_width_by_detail(details_by_file_name, key)
       if /^\d+$/.match?(details[key])
         print details[key].rjust(width)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -15,7 +15,7 @@ def main
   # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
   directory_path = directory_paths[0] || './'
   file_names = fetch_file_names(directory_path, options)
-  output(file_names, target_directory_path, options)
+  output(file_names, directory_path, options)
 end
 
 def parse_options(argv)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -24,8 +24,12 @@ def fetch_file_details(target_directory_path, options)
   if options[:l]
     file_details.each do |file_detail|
       stat = File.stat("#{target_directory_path}/#{file_detail[:name]}")
-      file_detail[:ctime] = stat.ctime
+      file_detail[:mode] = stat.mode
+      file_detail[:hardlink_count] = stat.nlink
+      file_detail[:owner_user] = stat.uid
+      file_detail[:owner_group] = stat.gid
       file_detail[:size] = stat.size
+      file_detail[:ctime] = stat.ctime
     end
   end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -58,12 +58,9 @@ end
 def output_long_listing_format(target_directory_path, file_names, options)
   file_names.each do |file_name| 
     stat = File.stat("#{target_directory_path}/#{file_name}")
-    file_type_num = format("%06o",stat.mode).slice(0..1) 
-    file_type_str = FILE_TYPE_LIST[file_type_num]
 
     detail_str =
-      "#{file_type_str} "\
-      "#{format("%06o",stat.mode)} "\
+      "#{convert_file_mode_to_str(stat)} "\
       "#{stat.nlink} "\
       "#{Etc.getpwuid(stat.uid).name} "\
       "#{Etc.getgrgid(stat.gid).name} "\
@@ -72,6 +69,36 @@ def output_long_listing_format(target_directory_path, file_names, options)
       "#{file_name}"
     puts detail_str
   end
+end
+
+def convert_file_mode_to_str(stat)
+  file_type_num = format("%06o",stat.mode).slice(0..1) 
+  file_type_str = FILE_TYPE_LIST[file_type_num]
+
+  permission_num = format("%06o",stat.mode).slice(3..5)
+  permission_str = convert_permission_num_to_str(permission_num)
+
+  file_type_str + permission_str
+
+end
+
+def convert_permission_num_to_str(permission_num)
+  permission_str_array = []
+  permission_num.chars.each do |nc|
+    n = nc.to_i
+    permission_array = ["-","-","-"]
+    if n / 4 == 1
+      permission_array[0] = "r"
+    end
+    if (n / 2) % 2 == 1
+      permission_array[1] = "w"
+    end
+    if n % 2 == 1
+      permission_array[2] = "x"
+    end
+    permission_str_array +=  permission_array
+  end
+  permission_str_array.join
 end
 
 # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -45,9 +45,10 @@ def output(file_names, target_directory_path, options)
 end
 
 def output_long_listing_format(file_names, target_directory_path)
+  block_count_total = 0
   file_names.each do |file_name|
     stat = File.stat("#{target_directory_path}/#{file_name}")
-
+    block_count_total += stat.blocks
     detail_str =
       "#{convert_stat_mode_to_str(stat.mode)} "\
       "#{stat.nlink} "\
@@ -58,6 +59,7 @@ def output_long_listing_format(file_names, target_directory_path)
       "#{file_name}"
     puts detail_str
   end
+  puts "total #{block_count_total}"
 end
 
 def output_default_format(file_names)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -82,27 +82,27 @@ def output_default_format(file_names)
 end
 
 def convert_stat_mode_to_str(stat_mode)
-  file_type_num = format('%06o', stat_mode).slice(0..1)
-  file_type_str = FILE_TYPE_LIST[file_type_num]
+  file_type_code = format('%06o', stat_mode).slice(0..1)
+  file_type_char = FILE_TYPE_LIST[file_type_code]
 
-  permission_num = format('%06o', stat_mode).slice(3..5)
-  permission_str = convert_permission_num_to_str(permission_num)
+  permission_code = format('%06o', stat_mode).slice(3..5)
+  permission_str = convert_permission_code_to_str(permission_code)
 
-  file_type_str + permission_str
+  file_type_char + permission_str
 end
 
-def convert_permission_num_to_str(permission_num)
-  permission_num_digits = permission_num.chars.map(&:to_i)
-  partial_permission_strings = permission_num_digits.map do |digit|
-    partial_permission_string = '-' * 3
+def convert_permission_code_to_str(permission_code)
+  permission_code_nums = permission_code.chars.map(&:to_i)
+  permission_octets = permission_code_nums.map do |num|
+    permission_octet = '-' * 3
 
-    partial_permission_string[0] = 'r' if digit / 4 == 1
-    partial_permission_string[1] = 'w' if (digit / 2).odd?
-    partial_permission_string[2] = 'x' if digit.odd?
+    permission_octet[0] = 'r' if num / 4 == 1
+    permission_octet[1] = 'w' if (num / 2).odd?
+    permission_octet[2] = 'x' if num.odd?
 
-    partial_permission_string
+    permission_octet
   end
-  partial_permission_strings.join
+  permission_octets.join
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -11,19 +11,25 @@ def parse_options(argv)
   options = {}
   opt.on('-a') { |v| options[:a] = v }
   opt.on('-r') { |v| options[:r] = v }
+  opt.on('-l') { |v| options[:l] = v }
   directory_paths = opt.parse(argv)
   [options, directory_paths]
 end
 
-def fetch_file_names(target_directory_path, options)
+def fetch_file_details(target_directory_path, options)
   dotmatch_flag = options[:a] ? File::FNM_DOTMATCH : 0
   file_names = Dir.glob('*', dotmatch_flag, base: target_directory_path)
+  file_details = file_names.map { |filename| { name: filename } }
 
-  stats = file_names.map{|file_name| File.stat("#{target_directory_path}/#{file_name}")}
-  
-  stats.each {|stat| puts  "#{stat.ctime} #{stat.size}"}
+  if options[:l]
+    file_details.each do |file_detail|
+      stat = File.stat("#{target_directory_path}/#{file_detail[:name]}")
+      file_detail[:ctime] = stat.ctime
+      file_detail[:size] = stat.size
+    end
+  end
 
-  options[:r] ? file_names.reverse : file_names
+  options[:r] ? file_details.reverse : file_details
 end
 
 def output(file_names)
@@ -50,5 +56,6 @@ end
 # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
 options, directory_paths = parse_options(ARGV)
 directory_path = directory_paths[0] || './'
-file_names = fetch_file_names(directory_path, options)
-output(file_names)
+file_dtails = fetch_file_details(directory_path, options)
+puts file_dtails
+# output(file_names)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -94,13 +94,13 @@ end
 def convert_permission_code_to_str(permission_code)
   permission_code_nums = permission_code.chars.map(&:to_i)
   permission_octets = permission_code_nums.map do |num|
-    permission_octet = '-' * 3
+    permission_octet_chars = []
 
-    permission_octet[0] = 'r' if num / 4 == 1
-    permission_octet[1] = 'w' if (num / 2).odd?
-    permission_octet[2] = 'x' if num.odd?
+    permission_octet_chars << (num / 4 == 1 ? 'r' : '-')
+    permission_octet_chars << ((num / 2).odd? ? 'w' : '-')
+    permission_octet_chars << (num.odd? ? 'x' : '-')
 
-    permission_octet
+    permission_octet_chars.join
   end
   permission_octets.join
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -8,8 +8,8 @@ MAX_COL_COUNT = 3
 SPACE_WIDTH = 2
 
 FILE_TYPE_LIST = { '01' => 'p', '02' => 'c', '04' => 'd', '06' => 'b', '10' => '-', '12' => 'l', '14' => 's' }.freeze
-
 DETAILS_OUTPUT_ORDER = %i[stat_mode nlink username groupname size ctime]
+RJUST_LIST = %i[nlink size ]
 
 def main
   options, directory_paths = parse_options(ARGV)
@@ -56,7 +56,7 @@ def output_long_listing_format(file_names, directory_path)
 
     DETAILS_OUTPUT_ORDER.each do |key|
       width = calc_max_width_by_detail(details_by_file_name, key)
-      if /^\d+$/.match?(details[key])
+      if RJUST_LIST.include?(key)
         print details[key].rjust(width)
       else
         print details[key].ljust(width)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -45,17 +45,9 @@ def output(file_names, target_directory_path, options)
 end
 
 def output_long_listing_format(file_names, target_directory_path)
-  block_count_total = 0
-  details_by_file_name = {}
+  details_by_file_name = get_details_by_file_name(file_names, target_directory_path)
 
-  file_names.each do |file_name|
-    stat = File.stat("#{target_directory_path}/#{file_name}")
-    block_count_total += stat.blocks
-    details = convert_stat_to_details(stat)
-    details_by_file_name[file_name] = details
-  end
-
-  puts "total #{block_count_total}"
+  puts "total #{calc_block_count_total(file_names, target_directory_path)}"
 
   file_names.each do |file_name|
     details = details_by_file_name[file_name]
@@ -70,6 +62,24 @@ def output_long_listing_format(file_names, target_directory_path)
     end
     puts file_name
   end
+end
+
+def get_details_by_file_name(file_names, target_directory_path)
+  details_by_file_name = {}
+  file_names.each do |file_name|
+    stat = File.stat("#{target_directory_path}/#{file_name}")
+    details = convert_stat_to_details(stat)
+    details_by_file_name[file_name] = details
+  end
+  details_by_file_name
+end
+
+def calc_block_count_total(file_names, target_directory_path)
+  block_count_total = 0
+  file_names.each do |file_name|
+    block_count_total += File.stat("#{target_directory_path}/#{file_name}").blocks
+  end
+  block_count_total
 end
 
 def output_default_format(file_names)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -75,13 +75,11 @@ def calc_block_count_total(file_names, directory_path)
 end
 
 def build_details_by_file_name(file_names, directory_path)
-  details_by_file_name = {}
-  file_names.each do |file_name|
+  file_names.to_h do |file_name|
     stat = File.stat("#{directory_path}/#{file_name}")
     details = convert_stat_to_details(stat)
-    details_by_file_name[file_name] = details
+    [file_name, details]
   end
-  details_by_file_name
 end
 
 def convert_stat_to_details(stat)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -47,47 +47,49 @@ end
 def output_long_listing_format(file_names, target_directory_path)
   block_count_total = 0
 
-  details_list = {}
-  details_size = 0
+  details_by_file_name = {}
 
   file_names.each do |file_name|
     stat = File.stat("#{target_directory_path}/#{file_name}")
+
     details = []
-    details << "#{convert_stat_mode_to_str(stat.mode)}"
-    details << "#{stat.nlink}"
-    details << "#{Etc.getpwuid(stat.uid).name}"
-    details << "#{Etc.getgrgid(stat.gid).name}"
-    details << "#{stat.size}"
-    details << "#{stat.ctime.strftime('%b')}"
-    details << "#{stat.ctime.strftime('%-d')}"
-    details << "#{stat.ctime.strftime('%H:%M')}"
-    details << "#{file_name}"
+    details << convert_stat_mode_to_str(stat.mode).to_s
+    details << stat.nlink.to_s
+    details << Etc.getpwuid(stat.uid).name.to_s
+    details << Etc.getgrgid(stat.gid).name.to_s
+    details << stat.size.to_s
+    details << stat.ctime.strftime('%b').to_s
+    details << stat.ctime.strftime('%-d').to_s
+    details << stat.ctime.strftime('%H:%M').to_s
+    details << file_name.to_s
+
     block_count_total += stat.blocks
-    details_size = details.size
-    details_list["#{file_name}"] = details
+
+    details_by_file_name[file_name.to_s] = details
   end
 
-  widths = []
+  details_size = details_by_file_name[file_names[0]].size
+
+  max_widths_by_detail = []
   details_size.times do |index|
-    lengths = details_list.map{|file_name, details| details[index].length}
-    widths << lengths.max + 1
+    detail_widths_by_file_name = details_by_file_name.map { |_file_name, details| details[index].length }
+    max_widths_by_detail << detail_widths_by_file_name.max
   end
-  p widths
 
   puts "total #{block_count_total}"
 
-
   file_names.each do |file_name|
-    details_size.times do |index| 
-      if  /^\d+$/.match("#{details_list["#{file_name}"][index]}")
-        print "#{details_list["#{file_name}"][index]} ".rjust(widths[index])
+    details_size.times do |index|
+      target_detail = details_by_file_name[file_name.to_s][index].to_s
+      if /^\d+$/.match?(target_detail)
+        print target_detail.rjust(max_widths_by_detail[index])
       else
-        print "#{details_list["#{file_name}"][index]}".ljust(widths[index])
+        print target_detail.ljust(max_widths_by_detail[index])
       end
+      print ' '
     end
     print "\n"
   end
-
 end
 
 def output_default_format(file_names)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -84,14 +84,14 @@ def build_details_by_file_name(file_names, directory_path)
 end
 
 def convert_stat_to_details(stat)
-  details = {}
-  details[:stat_mode] = convert_stat_mode_to_str(stat.mode)
-  details[:nlink] = stat.nlink.to_s
-  details[:username] = Etc.getpwuid(stat.uid).name
-  details[:groupname] = Etc.getgrgid(stat.gid).name
-  details[:size] = stat.size.to_s
-  details[:ctime] = stat.ctime.strftime('%b %e %H:%M')
-  details
+  details = {
+  stat_mode: convert_stat_mode_to_str(stat.mode),
+  nlink: stat.nlink.to_s,
+  username: Etc.getpwuid(stat.uid).name,
+  groupname: Etc.getgrgid(stat.gid).name,
+  size: stat.size.to_s,
+  ctime: stat.ctime.strftime('%b %e %H:%M'),
+  }
 end
 
 def convert_stat_mode_to_str(stat_mode)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -11,25 +11,19 @@ def parse_options(argv)
   options = {}
   opt.on('-a') { |v| options[:a] = v }
   opt.on('-r') { |v| options[:r] = v }
-  opt.on('-l') { |v| options[:l] = v }
   directory_paths = opt.parse(argv)
   [options, directory_paths]
 end
 
-def fetch_file_details(target_directory_path, options)
+def fetch_file_names(target_directory_path, options)
   dotmatch_flag = options[:a] ? File::FNM_DOTMATCH : 0
   file_names = Dir.glob('*', dotmatch_flag, base: target_directory_path)
-  file_details = file_names.map { |filename| { name: filename } }
 
-  if options[:l]
-    file_details.each do |file_detail|
-      stat = File.stat("#{target_directory_path}/#{file_detail[:name]}")
-      file_detail[:ctime] = stat.ctime
-      file_detail[:size] = stat.size
-    end
-  end
+  stats = file_names.map{|file_name| File.stat("#{target_directory_path}/#{file_name}")}
+  
+  stats.each {|stat| puts  "#{stat.ctime} #{stat.size}"}
 
-  options[:r] ? file_details.reverse : file_details
+  options[:r] ? file_names.reverse : file_names
 end
 
 def output(file_names)
@@ -56,6 +50,5 @@ end
 # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
 options, directory_paths = parse_options(ARGV)
 directory_path = directory_paths[0] || './'
-file_dtails = fetch_file_details(directory_path, options)
-puts file_dtails
-# output(file_names)
+file_names = fetch_file_names(directory_path, options)
+output(file_names)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -95,14 +95,12 @@ end
 
 def convert_stat_to_details(stat)
   details = []
-  details << convert_stat_mode_to_str(stat.mode).to_s
+  details << convert_stat_mode_to_str(stat.mode)
   details << stat.nlink.to_s
-  details << Etc.getpwuid(stat.uid).name.to_s
-  details << Etc.getgrgid(stat.gid).name.to_s
+  details << Etc.getpwuid(stat.uid).name
+  details << Etc.getgrgid(stat.gid).name
   details << stat.size.to_s
-  details << stat.ctime.strftime('%b').to_s
-  details << stat.ctime.strftime('%-d').to_s
-  details << stat.ctime.strftime('%H:%M').to_s
+  details << stat.ctime.strftime('%b %e %H:%M')
 end
 
 def fetch_max_widths_by_detail(details_by_file_name)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -56,7 +56,7 @@ def output_long_listing_format(file_names, target_directory_path)
     details_by_file_name[file_name] = details
   end
 
-  max_widths_by_detail = fetch_max_widths_by_detail(details_by_file_name)
+  max_widths_by_detail = get_max_widths_by_detail(details_by_file_name)
 
   puts "total #{block_count_total}"
 
@@ -103,7 +103,7 @@ def convert_stat_to_details(stat)
   details << stat.ctime.strftime('%b %e %H:%M')
 end
 
-def fetch_max_widths_by_detail(details_by_file_name)
+def get_max_widths_by_detail(details_by_file_name)
   max_widths_by_detail = []
   details_size = details_by_file_name.values[0].length
   details_size.times do |index|

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -7,7 +7,7 @@ require 'etc'
 MAX_COL_COUNT = 3
 SPACE_WIDTH = 2
 
-FILE_TYPE_LIST = {"01"=>"p", "02"=>"c", "04"=>"d", "06"=>"b", "10"=>"-", "12"=>"l", "14"=>"s"}
+FILE_TYPE_LIST = { '01' => 'p', '02' => 'c', '04' => 'd', '06' => 'b', '10' => '-', '12' => 'l', '14' => 's' }.freeze
 
 def parse_options(argv)
   opt = OptionParser.new
@@ -26,14 +26,14 @@ def fetch_file_names(target_directory_path, options)
   options[:r] ? file_names.reverse : file_names
 end
 
-def output(target_directory_path, file_names, options)
+def output(file_names, target_directory_path, options)
   return if file_names.empty?
 
   if options[:l]
-    output_long_listing_format(target_directory_path, file_names, options) 
-  else 
-    output_default_format(file_names) 
-  end 
+    output_long_listing_format(file_names, target_directory_path)
+  else
+    output_default_format(file_names)
+  end
 end
 
 def output_default_format(file_names)
@@ -55,48 +55,43 @@ def output_default_format(file_names)
   end
 end
 
-def output_long_listing_format(target_directory_path, file_names, options)
-  file_names.each do |file_name| 
+def output_long_listing_format(file_names, target_directory_path)
+  file_names.each do |file_name|
     stat = File.stat("#{target_directory_path}/#{file_name}")
 
     detail_str =
-      "#{convert_file_mode_to_str(stat)} "\
+      "#{convert_stat_mode_to_str(stat.mode)} "\
       "#{stat.nlink} "\
       "#{Etc.getpwuid(stat.uid).name} "\
       "#{Etc.getgrgid(stat.gid).name} "\
       "#{stat.size} "\
-      "#{stat.ctime.strftime("%b %-d %H:%M")} "\
+      "#{stat.ctime.strftime('%b %-d %H:%M')} "\
       "#{file_name}"
     puts detail_str
   end
 end
 
-def convert_file_mode_to_str(stat)
-  file_type_num = format("%06o",stat.mode).slice(0..1) 
+def convert_stat_mode_to_str(stat_mode)
+  file_type_num = format('%06o', stat_mode).slice(0..1)
   file_type_str = FILE_TYPE_LIST[file_type_num]
 
-  permission_num = format("%06o",stat.mode).slice(3..5)
+  permission_num = format('%06o', stat_mode).slice(3..5)
   permission_str = convert_permission_num_to_str(permission_num)
 
   file_type_str + permission_str
-
 end
 
 def convert_permission_num_to_str(permission_num)
   permission_str_array = []
   permission_num.chars.each do |nc|
     n = nc.to_i
-    permission_array = ["-","-","-"]
-    if n / 4 == 1
-      permission_array[0] = "r"
-    end
-    if (n / 2) % 2 == 1
-      permission_array[1] = "w"
-    end
-    if n % 2 == 1
-      permission_array[2] = "x"
-    end
-    permission_str_array +=  permission_array
+    permission_array = Array.new(3, '-')
+
+    permission_array[0] = 'r' if n / 4 == 1
+    permission_array[1] = 'w' if (n / 2).odd?
+    permission_array[2] = 'x' if n.odd?
+
+    permission_str_array += permission_array
   end
   permission_str_array.join
 end
@@ -105,4 +100,4 @@ end
 options, directory_paths = parse_options(ARGV)
 target_directory_path = directory_paths[0] || './'
 file_names = fetch_file_names(target_directory_path, options)
-output(target_directory_path, file_names, options)
+output(file_names, target_directory_path, options)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -36,44 +36,30 @@ def fetch_file_details(target_directory_path, options)
   options[:r] ? file_details.reverse : file_details
 end
 
-def output(file_details, options)
-  return if file_details.empty?
+def output(file_names)
+  return if file_names.empty?
 
-  if options[:l]
-    file_details.each do |file_detail|
-      print file_detail[:mode] # 要変換
-      print file_detail[:hardlink_count]
-      print file_detail[:owner_user] # 要変換
-      print file_detail[:owner_group] # 要変換
-      print file_detail[:size]
-      print file_detail[:ctime]
-      print file_detail[:name]
-      puts
+  row_count = ((file_names.size - 1) / MAX_COL_COUNT) + 1
+  col_count = [file_names.size, MAX_COL_COUNT].min
+
+  # NOTE: OS標準のlsコマンドは横並びではなく縦並びで出力される(転置して出力される)
+  # NOTE: file_names_tableの要素は行と列が出力したい形(縦並び)とは逆で保存されている
+  file_names_table = file_names.each_slice(row_count).to_a
+  widths = file_names_table.map { |col| col.map(&:size).max + SPACE_WIDTH }
+
+  row_count.times do |row_index|
+    col_count.times do |col_index|
+      # file_names_tableの行と列が逆で保存されているので、col_indexとrow_indexを入れ替えて出力させている
+      target_file_name = file_names_table[col_index][row_index]
+      print target_file_name&.ljust(widths[col_index])
     end
-
-  else
-    row_count = ((file_details.size - 1) / MAX_COL_COUNT) + 1
-    col_count = [file_details.size, MAX_COL_COUNT].min
-
-    # NOTE: OS標準のlsコマンドは横並びではなく縦並びで出力される(転置して出力される)
-    # NOTE: file_names_tableの要素は行と列が出力したい形(縦並び)とは逆で保存されている
-    file_details_table = file_details.each_slice(row_count).to_a
-    widths = file_details_table.map { |col| col.map{|detail| detail[:name].size}.max + SPACE_WIDTH }
-
-    row_count.times do |row_index|
-      col_count.times do |col_index|
-        # file_names_tableの行と列が逆で保存されているので、col_indexとrow_indexを入れ替えて出力させている
-        target_file_detail = file_details_table[col_index][row_index]
-        print target_file_detail[:name].ljust(widths[col_index]) unless target_file_detail.nil? # 要修正
-      end
-      print "\n"
-    end
+    print "\n"
   end
-    
 end
 
 # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
 options, directory_paths = parse_options(ARGV)
 directory_path = directory_paths[0] || './'
-file_details = fetch_file_details(directory_path, options)
-output(file_details, options)
+file_dtails = fetch_file_details(directory_path, options)
+puts file_dtails
+# output(file_names)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -24,12 +24,8 @@ def fetch_file_details(target_directory_path, options)
   if options[:l]
     file_details.each do |file_detail|
       stat = File.stat("#{target_directory_path}/#{file_detail[:name]}")
-      file_detail[:mode] = stat.mode
-      file_detail[:hardlink_count] = stat.nlink
-      file_detail[:owner_user] = stat.uid
-      file_detail[:owner_group] = stat.gid
-      file_detail[:size] = stat.size
       file_detail[:ctime] = stat.ctime
+      file_detail[:size] = stat.size
     end
   end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -24,10 +24,10 @@ def fetch_file_details(target_directory_path, options)
   if options[:l]
     file_details.each do |file_detail|
       stat = File.stat("#{target_directory_path}/#{file_detail[:name]}")
-      file_detail[:mode] = stat.mode # 要変換
+      file_detail[:mode] = stat.mode
       file_detail[:hardlink_count] = stat.nlink
-      file_detail[:owner_user] = stat.uid # 要変換
-      file_detail[:owner_group] = stat.gid # 要変換
+      file_detail[:owner_user] = stat.uid
+      file_detail[:owner_group] = stat.gid
       file_detail[:size] = stat.size
       file_detail[:ctime] = stat.ctime
     end
@@ -41,15 +41,14 @@ def output(file_details, options)
 
   if options[:l]
     file_details.each do |file_detail|
-      detail_str = 
-        "#{file_detail[:mode]} "\
-        "#{file_detail[:hardlink_count]} "\
-        "#{file_detail[:owner_user]} "\
-        "#{file_detail[:owner_group]} "\
-        "#{file_detail[:size]} "\
-        "#{file_detail[:ctime]} "\
-        "#{file_detail[:name]}"
-      puts detail_str
+      print file_detail[:mode] # 要変換
+      print file_detail[:hardlink_count]
+      print file_detail[:owner_user] # 要変換
+      print file_detail[:owner_group] # 要変換
+      print file_detail[:size]
+      print file_detail[:ctime]
+      print file_detail[:name]
+      puts
     end
 
   else

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -47,14 +47,14 @@ end
 def output_long_listing_format(file_names, target_directory_path)
   puts "total #{calc_block_count_total(file_names, target_directory_path)}"
 
-  details_by_file_name = get_details_by_file_name(file_names, target_directory_path)
+  details_by_file_name = build_details_by_file_name(file_names, target_directory_path)
 
   file_names.each do |file_name|
     details = details_by_file_name[file_name]
     details_output_order = %i[stat_mode nlink username groupname size ctime]
 
     details_output_order.each do |key|
-      width = get_max_width_by_detail(details_by_file_name, key)
+      width = calc_max_width_by_detail(details_by_file_name, key)
       if /^\d+$/.match?(details[key])
         print details[key].rjust(width)
       else
@@ -74,7 +74,7 @@ def calc_block_count_total(file_names, target_directory_path)
   block_count_total
 end
 
-def get_details_by_file_name(file_names, target_directory_path)
+def build_details_by_file_name(file_names, target_directory_path)
   details_by_file_name = {}
   file_names.each do |file_name|
     stat = File.stat("#{target_directory_path}/#{file_name}")
@@ -119,7 +119,7 @@ def convert_permission_code_to_str(permission_code)
   permission_octets.join
 end
 
-def get_max_width_by_detail(details_by_file_name, key)
+def calcu_max_width_by_detail(details_by_file_name, key)
   detail_widths_by_file_name = details_by_file_name.map { |_file_name, details| details[key].length }
   detail_widths_by_file_name.max
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -45,12 +45,13 @@ def output(file_names, target_directory_path, options)
 end
 
 def output_long_listing_format(file_names, target_directory_path)
-  details_by_file_name = get_details_by_file_name(file_names, target_directory_path)
-
   puts "total #{calc_block_count_total(file_names, target_directory_path)}"
+
+  details_by_file_name = get_details_by_file_name(file_names, target_directory_path)
 
   file_names.each do |file_name|
     details = details_by_file_name[file_name]
+
     details.each_with_index do |detail, index|
       width = get_max_width_by_detail(details_by_file_name, index)
       if /^\d+$/.match?(detail)
@@ -64,6 +65,14 @@ def output_long_listing_format(file_names, target_directory_path)
   end
 end
 
+def calc_block_count_total(file_names, target_directory_path)
+  block_count_total = 0
+  file_names.each do |file_name|
+    block_count_total += File.stat("#{target_directory_path}/#{file_name}").blocks
+  end
+  block_count_total
+end
+
 def get_details_by_file_name(file_names, target_directory_path)
   details_by_file_name = {}
   file_names.each do |file_name|
@@ -74,33 +83,6 @@ def get_details_by_file_name(file_names, target_directory_path)
   details_by_file_name
 end
 
-def calc_block_count_total(file_names, target_directory_path)
-  block_count_total = 0
-  file_names.each do |file_name|
-    block_count_total += File.stat("#{target_directory_path}/#{file_name}").blocks
-  end
-  block_count_total
-end
-
-def output_default_format(file_names)
-  row_count = ((file_names.size - 1) / MAX_COL_COUNT) + 1
-  col_count = [file_names.size, MAX_COL_COUNT].min
-
-  # NOTE: OS標準のlsコマンドは横並びではなく縦並びで出力される(転置して出力される)
-  # NOTE: file_names_tableの要素は行と列が出力したい形(縦並び)とは逆で保存されている
-  file_names_table = file_names.each_slice(row_count).to_a
-  widths = file_names_table.map { |col| col.map(&:size).max + SPACE_WIDTH }
-
-  row_count.times do |row_index|
-    col_count.times do |col_index|
-      # file_names_tableの行と列が逆で保存されているので、col_indexとrow_indexを入れ替えて出力させている
-      target_file_name = file_names_table[col_index][row_index]
-      print target_file_name&.ljust(widths[col_index])
-    end
-    print "\n"
-  end
-end
-
 def convert_stat_to_details(stat)
   details = []
   details << convert_stat_mode_to_str(stat.mode)
@@ -109,11 +91,6 @@ def convert_stat_to_details(stat)
   details << Etc.getgrgid(stat.gid).name
   details << stat.size.to_s
   details << stat.ctime.strftime('%b %e %H:%M')
-end
-
-def get_max_width_by_detail(details_by_file_name, index)
-  detail_widths_by_file_name = details_by_file_name.map { |_file_name, details| details[index].length }
-  detail_widths_by_file_name.max
 end
 
 def convert_stat_mode_to_str(stat_mode)
@@ -138,6 +115,30 @@ def convert_permission_code_to_str(permission_code)
     permission_octet_chars.join
   end
   permission_octets.join
+end
+
+def get_max_width_by_detail(details_by_file_name, index)
+  detail_widths_by_file_name = details_by_file_name.map { |_file_name, details| details[index].length }
+  detail_widths_by_file_name.max
+end
+
+def output_default_format(file_names)
+  row_count = ((file_names.size - 1) / MAX_COL_COUNT) + 1
+  col_count = [file_names.size, MAX_COL_COUNT].min
+
+  # NOTE: OS標準のlsコマンドは横並びではなく縦並びで出力される(転置して出力される)
+  # NOTE: file_names_tableの要素は行と列が出力したい形(縦並び)とは逆で保存されている
+  file_names_table = file_names.each_slice(row_count).to_a
+  widths = file_names_table.map { |col| col.map(&:size).max + SPACE_WIDTH }
+
+  row_count.times do |row_index|
+    col_count.times do |col_index|
+      # file_names_tableの行と列が逆で保存されているので、col_indexとrow_indexを入れ替えて出力させている
+      target_file_name = file_names_table[col_index][row_index]
+      print target_file_name&.ljust(widths[col_index])
+    end
+    print "\n"
+  end
 end
 
 main


### PR DESCRIPTION
「[lsコマンドを作る4](https://bootcamp.fjord.jp/practices/224#learning-Status)」の課題としてlsコマンドに-l オプションを追加しました。

## 要件
lsコマンド全体の要件については下記参照↓
[lsコマンドを作る](https://bootcamp.fjord.jp/pages/ls-command#requirements)

-l オプションについてはOS標準のものに合わせるとのこと

## 実行結果
### 作成したlsコマンドの実行結果
上から順に
1. オプション無
1. -lオプション有
で実行しています。


![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBek12QXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--7fd25af6e8ec10308726715964599af85558da5e/image.png)




## OS標準のlsコマンドの実行結果
同様に上から順に
1. オプション無
1. -lオプション有
で実行しています。

![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBelF2QXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--d7d8e6c7621ecc1af37c56f9483f32b4c213672f/image.png)

## rubocopのチェック
rubocopのチェックはパスしています。
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBeXd2QXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--174abb7cd9267d8f527ba27d3b81cb60d0a8a361/image.png)


## 必須要件かわからない点
OS標準のlsコマンドは各項目が幅揃えされているのですが、この動作は必須要件でしょうか。
この部分については[こちらのコメント](https://github.com/cellotak/ruby-practices/pull/9/files#r1318199169)に詳しく記載させて頂いてます。
![image](https://github.com/cellotak/ruby-practices/assets/65953037/22bf7f03-8a38-4498-ab17-186ba7753aa0)



## その他補足
- 「-aオプションや-rオプションは実装しなくてよいです。」とありましたが、特に他のオプションがデグレードする要素がなかったため、オプションは残っており、また併用することができます。
- -lオプション無しの時、平仮名や漢字にすると、左揃えでなくなる問題には手をつけていません。
- ディレクトリ名は指定できますが、ファイル名の指定や複数ディレクトリの指定には対応していません。(どこかのタイミングで対応したいとは思っています。)
- lsコマンドにaliasを設定しており、lsと打つとディレクトリ名は青色になるなど、標準とは異なる表示がされてしまうので、\lsという形で実行しています。
- OS標準のlsコマンドとはソートのルールが違うようで、出力順は異なっています。


