### PR TITLE
「lsコマンドを作る5」の課題

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -59,9 +59,7 @@ def output_long_listing_format(file_names, directory_path)
 
   max_width_by_detail = calc_max_width_by_detail(details_by_file_name)
 
-  file_names.each do |file_name|
-    details = details_by_file_name[file_name]
-
+  details_by_file_name.each do |file_name, details|
     DETAILS_KEYS.each do |key|
       if RJUST_KEYS.include?(key)
         print details[key].rjust(max_width_by_detail[key])

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -12,11 +12,16 @@ DETAILS_OUTPUT_ORDER = %i[stat_mode nlink username groupname size ctime].freeze
 RJUST_LIST = %i[nlink size].freeze
 
 def main
-  options, directory_paths = parse_options(ARGV)
+  options, paths = parse_options(ARGV)
   # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
-  directory_path = directory_paths[0] || './'
-  file_names = fetch_file_names(directory_path, options)
-  output(file_names, directory_path, options)
+  path = paths[0] || './'
+  if File.file?(path)
+    puts path
+  elsif File.directory?(path)
+    directory_path = path
+    file_names = fetch_file_names(directory_path, options)
+    output(file_names, directory_path, options)
+  end
 end
 
 def parse_options(argv)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -69,10 +69,10 @@ def output_long_listing_format(file_names, directory_path)
 end
 
 def calc_block_count_total(file_names, directory_path)
-  file_names.map do |file_name|
+  file_names.sum do |file_name|
     file_path = "#{directory_path}/#{file_name}"
     File.stat(file_path).blocks
-  end.sum
+  end
 end
 
 def build_details_by_file_name(file_names, directory_path)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -14,22 +14,29 @@ RJUST_LIST = %i[nlink size].freeze
 def main
   options, paths = parse_options(ARGV)
   # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
-  path = paths[0] || './'
-  # if File.file?(path)
-  #   puts path
-  # elsif File.directory?(path)
-  #   directory_path = path
-  #   file_names = fetch_file_names(directory_path, options)
-  #   output(file_names, directory_path, options)
-  # end
-  if File.directory?(path)
-    directory_path = path
+
+  paths << './' if paths.empty?
+
+  directory_paths = []
+  file_paths = []
+
+  paths.each do |path|
+    if File.directory?(path)
+      directory_paths << path
+    elsif File.file?(path)
+      file_paths << path
+    end
+  end
+
+  file_name_specified_output(file_paths, options)
+
+  directory_paths.each do |directory_path|
+    if paths.size >= 2
+      puts ""
+      puts "#{directory_path}:"
+    end
     file_names = fetch_file_names(directory_path, options)
     output(file_names, directory_path, options)
-  elsif File.file?(path)
-    file_names = [File.basename(path)]
-    directory_path = File.dirname(path)
-    file_name_specified_output(file_names, directory_path, options)
   end
 end
 
@@ -168,15 +175,21 @@ def ljust_include_multibyte_characters(ljust_target, width)
   ljust_target.ljust(adjusted_width)
 end
 
-def file_name_specified_output(file_names, directory_path, options)
-  file_name = file_names[0]
+def file_name_specified_output(file_paths, options)
   if options[:l]
-    details_by_file_name = build_details_by_file_name(file_names, directory_path)
-    DETAILS_OUTPUT_ORDER.each do |key|
-      print "#{details_by_file_name[file_name][key]} "
+    file_paths.each do |file_path|
+      file_name = File.basename(file_path)
+      directory_path = File.dirname(file_path)
+      stat = File.stat("#{directory_path}/#{file_name}")
+      details = convert_stat_to_details(stat)
+      DETAILS_OUTPUT_ORDER.each do |key|
+        print "#{details[key]} "
+      end
+      print "#{file_path}\n"
     end
+  else
+    output_default_format(file_paths)
   end
-  puts "#{directory_path}/#{file_name}"
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -16,12 +16,10 @@ def main
   # pathsには複数のpathを指定することは許容しているが、ファイル名を表示するのは1番目に指定したディレクトリorファイルのみにしている。
   path = paths[0] || './'
   if File.directory?(path)
-    directory_path = path
-    file_names = fetch_file_names(directory_path, options)
-    output(file_names, directory_path, options)
+    file_names = fetch_file_names(path, options)
+    output(file_names, path, options)
   elsif File.file?(path)
-    file_path = path
-    file_name_specified_output(file_path, options)
+    output_single_file(path, options)
   end
 end
 
@@ -158,7 +156,7 @@ def ljust_include_multibyte_characters(ljust_target, width)
   ljust_target.ljust(adjusted_width)
 end
 
-def file_name_specified_output(file_path, options)
+def output_single_file(file_path, options)
   if options[:l]
     stat = File.stat(file_path)
     details = convert_stat_to_details(stat)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -15,12 +15,21 @@ def main
   options, paths = parse_options(ARGV)
   # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
   path = paths[0] || './'
-  if File.file?(path)
-    puts path
-  elsif File.directory?(path)
+  # if File.file?(path)
+  #   puts path
+  # elsif File.directory?(path)
+  #   directory_path = path
+  #   file_names = fetch_file_names(directory_path, options)
+  #   output(file_names, directory_path, options)
+  # end
+  if File.directory?(path)
     directory_path = path
     file_names = fetch_file_names(directory_path, options)
     output(file_names, directory_path, options)
+  elsif File.file?(path)
+    file_names = [File.basename(path)]
+    directory_path = File.dirname(path)
+    file_name_specified_output(file_names, directory_path, options)
   end
 end
 
@@ -157,6 +166,17 @@ def ljust_include_multibyte_characters(ljust_target, width)
 
   adjusted_width = width - (calc_actual_length(ljust_target) - ljust_target.length)
   ljust_target.ljust(adjusted_width)
+end
+
+def file_name_specified_output(file_names, directory_path, options)
+  file_name = file_names[0]
+  if options[:l]
+    details_by_file_name = build_details_by_file_name(file_names, directory_path)
+    DETAILS_OUTPUT_ORDER.each do |key|
+      print "#{details_by_file_name[file_name][key]} "
+    end
+  end
+  puts "#{directory_path}/#{file_name}"
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -51,9 +51,9 @@ def output(file_names, directory_path, options)
 end
 
 def output_long_listing_format(file_names, directory_path)
-  puts "total #{calc_block_count_total(file_names, directory_path)}"
-
   details_by_file_name = build_details_by_file_name(file_names, directory_path)
+
+  puts "total #{calc_block_count_total(details_by_file_name)}"
 
   max_width_by_detail = calc_max_width_by_detail(details_by_file_name)
 
@@ -70,10 +70,9 @@ def output_long_listing_format(file_names, directory_path)
   end
 end
 
-def calc_block_count_total(file_names, directory_path)
-  file_names.sum do |file_name|
-    file_path = "#{directory_path}/#{file_name}"
-    File.stat(file_path).blocks
+def calc_block_count_total(details_by_file_name)
+  details_by_file_name.sum do |file_name, details|
+    details[:blocks]
   end
 end
 
@@ -92,7 +91,8 @@ def convert_stat_to_details(stat)
     username: Etc.getpwuid(stat.uid).name,
     groupname: Etc.getgrgid(stat.gid).name,
     size: stat.size.to_s,
-    ctime: stat.ctime.strftime('%b %e %H:%M')
+    ctime: stat.ctime.strftime('%b %e %H:%M'),
+    blocks: stat.blocks 
   }
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -58,11 +58,9 @@ def output_long_listing_format(file_names, directory_path)
 
   details_by_file_name.each do |file_name, details|
     DETAILS_KEYS.each do |key, align|
-      if align == :right
-        print details[key].rjust(max_width_by_detail[key])
-      else
-        print details[key].ljust(max_width_by_detail[key])
-      end
+      value = details[key]
+      width = max_width_by_detail[key]
+      print(align == :right ? value.rjust(width) : value.ljust(width))
       print ' '
     end
     puts file_name

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -14,29 +14,22 @@ RJUST_LIST = %i[nlink size].freeze
 def main
   options, paths = parse_options(ARGV)
   # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
-
-  paths << './' if paths.empty?
-
-  directory_paths = []
-  file_paths = []
-
-  paths.each do |path|
-    if File.directory?(path)
-      directory_paths << path
-    elsif File.file?(path)
-      file_paths << path
-    end
-  end
-
-  file_name_specified_output(file_paths, options)
-
-  directory_paths.each do |directory_path|
-    if paths.size >= 2
-      puts ""
-      puts "#{directory_path}:"
-    end
+  path = paths[0] || './'
+  # if File.file?(path)
+  #   puts path
+  # elsif File.directory?(path)
+  #   directory_path = path
+  #   file_names = fetch_file_names(directory_path, options)
+  #   output(file_names, directory_path, options)
+  # end
+  if File.directory?(path)
+    directory_path = path
     file_names = fetch_file_names(directory_path, options)
     output(file_names, directory_path, options)
+  elsif File.file?(path)
+    file_names = [File.basename(path)]
+    directory_path = File.dirname(path)
+    file_name_specified_output(file_names, directory_path, options)
   end
 end
 
@@ -175,21 +168,15 @@ def ljust_include_multibyte_characters(ljust_target, width)
   ljust_target.ljust(adjusted_width)
 end
 
-def file_name_specified_output(file_paths, options)
+def file_name_specified_output(file_names, directory_path, options)
+  file_name = file_names[0]
   if options[:l]
-    file_paths.each do |file_path|
-      file_name = File.basename(file_path)
-      directory_path = File.dirname(file_path)
-      stat = File.stat("#{directory_path}/#{file_name}")
-      details = convert_stat_to_details(stat)
-      DETAILS_OUTPUT_ORDER.each do |key|
-        print "#{details[key]} "
-      end
-      print "#{file_path}\n"
+    details_by_file_name = build_details_by_file_name(file_names, directory_path)
+    DETAILS_OUTPUT_ORDER.each do |key|
+      print "#{details_by_file_name[file_name][key]} "
     end
-  else
-    output_default_format(file_paths)
   end
+  puts "#{directory_path}/#{file_name}"
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -7,9 +7,9 @@ require 'etc'
 MAX_COL_COUNT = 3
 SPACE_WIDTH = 2
 
-FILE_TYPE_LIST = { '01' => 'p', '02' => 'c', '04' => 'd', '06' => 'b', '10' => '-', '12' => 'l', '14' => 's' }.freeze
-DETAILS_OUTPUT_ORDER = %i[stat_mode nlink username groupname size ctime].freeze
-RJUST_LIST = %i[nlink size].freeze
+FILE_TYPES = { '01' => 'p', '02' => 'c', '04' => 'd', '06' => 'b', '10' => '-', '12' => 'l', '14' => 's' }.freeze
+DETAILS_KEYS = %i[stat_mode nlink username groupname size ctime].freeze
+RJUST_KEYS = %i[nlink size].freeze
 
 def main
   options, paths = parse_options(ARGV)
@@ -62,8 +62,8 @@ def output_long_listing_format(file_names, directory_path)
   file_names.each do |file_name|
     details = details_by_file_name[file_name]
 
-    DETAILS_OUTPUT_ORDER.each do |key|
-      if RJUST_LIST.include?(key)
+    DETAILS_KEYS.each do |key|
+      if RJUST_KEYS.include?(key)
         print details[key].rjust(max_width_by_detail[key])
       else
         print details[key].ljust(max_width_by_detail[key])
@@ -102,7 +102,7 @@ end
 
 def convert_stat_mode_to_str(stat_mode)
   file_type_code = format('%06o', stat_mode).slice(0..1)
-  file_type_char = FILE_TYPE_LIST[file_type_code]
+  file_type_char = FILE_TYPES[file_type_code]
 
   permission_code = format('%06o', stat_mode).slice(3..5)
   permission_str = convert_permission_code_to_str(permission_code)
@@ -125,7 +125,7 @@ def convert_permission_code_to_str(permission_code)
 end
 
 def calc_max_width_by_detail(details_by_file_name)
-  DETAILS_OUTPUT_ORDER.to_h do |key|
+  DETAILS_KEYS.to_h do |key|
     widths_by_detail = details_by_file_name.map { |_file_name, details| calc_actual_length(details[key]) }
     [key, widths_by_detail.max]
   end
@@ -165,7 +165,7 @@ def file_name_specified_output(file_path, options)
     stat = File.stat(file_path)
     details = convert_stat_to_details(stat)
 
-    DETAILS_OUTPUT_ORDER.each do |key|
+    DETAILS_KEYS.each do |key|
       print "#{details[key]} "
     end
   end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -122,7 +122,7 @@ end
 
 def calc_max_width_by_detail(details_by_file_name)
   DETAILS_KEYS.to_h do |key|
-    widths_by_detail = details_by_file_name.map { |_file_name, details| calc_actual_length(details[key]) }
+    widths_by_detail = details_by_file_name.map { |_file_name, details| calc_display_length(details[key]) }
     [key, widths_by_detail.max]
   end
 end
@@ -134,25 +134,25 @@ def output_default_format(file_names)
   # NOTE: OS標準のlsコマンドは横並びではなく縦並びで出力される(転置して出力される)
   # NOTE: file_names_tableの要素は行と列が出力したい形(縦並び)とは逆で保存されている
   file_names_table = file_names.each_slice(row_count).to_a
-  widths = file_names_table.map { |col| col.map { |file_name| calc_actual_length(file_name) }.max + SPACE_WIDTH }
+  widths = file_names_table.map { |col| col.map { |file_name| calc_display_length(file_name) }.max + SPACE_WIDTH }
   row_count.times do |row_index|
     col_count.times do |col_index|
       # file_names_tableの行と列が逆で保存されているので、col_indexとrow_indexを入れ替えて出力させている
       target_file_name = file_names_table[col_index][row_index]
-      print ljust_include_multibyte_characters(target_file_name, widths[col_index])
+      print ljust_multibyte_chars(target_file_name, widths[col_index])
     end
     print "\n"
   end
 end
 
-def calc_actual_length(file_name)
+def calc_display_length(file_name)
   file_name.chars.sum { |char| char.bytesize == 1 ? 1 : 2 }
 end
 
-def ljust_include_multibyte_characters(ljust_target, width)
+def ljust_multibyte_chars(ljust_target, width)
   return nil if ljust_target.nil?
 
-  adjusted_width = width - (calc_actual_length(ljust_target) - ljust_target.length)
+  adjusted_width = width - (calc_display_length(ljust_target) - ljust_target.length)
   ljust_target.ljust(adjusted_width)
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -8,8 +8,7 @@ MAX_COL_COUNT = 3
 SPACE_WIDTH = 2
 
 FILE_TYPES = { '01' => 'p', '02' => 'c', '04' => 'd', '06' => 'b', '10' => '-', '12' => 'l', '14' => 's' }.freeze
-DETAILS_KEYS = %i[stat_mode nlink username groupname size ctime].freeze
-RJUST_KEYS = %i[nlink size].freeze
+DETAILS_KEYS = {stat_mode: :left, nlink: :right , username: :left, groupname: :left, size: :right, ctime: :left}.freeze
 
 def main
   options, paths = parse_options(ARGV)
@@ -58,8 +57,8 @@ def output_long_listing_format(file_names, directory_path)
   max_width_by_detail = calc_max_width_by_detail(details_by_file_name)
 
   details_by_file_name.each do |file_name, details|
-    DETAILS_KEYS.each do |key|
-      if RJUST_KEYS.include?(key)
+    DETAILS_KEYS.each do |key, align|
+      if align == :right
         print details[key].rjust(max_width_by_detail[key])
       else
         print details[key].ljust(max_width_by_detail[key])

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -8,7 +8,7 @@ MAX_COL_COUNT = 3
 SPACE_WIDTH = 2
 
 FILE_TYPES = { '01' => 'p', '02' => 'c', '04' => 'd', '06' => 'b', '10' => '-', '12' => 'l', '14' => 's' }.freeze
-DETAILS_KEYS = {stat_mode: :left, nlink: :right , username: :left, groupname: :left, size: :right, ctime: :left}.freeze
+DETAILS_KEYS = { stat_mode: :left, nlink: :right, username: :left, groupname: :left, size: :right, ctime: :left }.freeze
 
 def main
   options, paths = parse_options(ARGV)
@@ -18,7 +18,10 @@ def main
     file_names = fetch_file_names(path, options)
     output(file_names, path, options)
   elsif File.file?(path)
-    output_single_file(path, options)
+    file_path = File.basename(path)
+    file_names = [file_path]
+    directory_path = File.dirname(path)
+    output(file_names, directory_path, options)
   end
 end
 
@@ -68,7 +71,7 @@ def output_long_listing_format(file_names, directory_path)
 end
 
 def calc_block_count_total(details_by_file_name)
-  details_by_file_name.sum do |file_name, details|
+  details_by_file_name.sum do |_file_name, details|
     details[:blocks]
   end
 end
@@ -89,7 +92,7 @@ def convert_stat_to_details(stat)
     groupname: Etc.getgrgid(stat.gid).name,
     size: stat.size.to_s,
     ctime: stat.ctime.strftime('%b %e %H:%M'),
-    blocks: stat.blocks 
+    blocks: stat.blocks
   }
 end
 
@@ -151,18 +154,6 @@ def ljust_multibyte_chars(ljust_target, width)
 
   adjusted_width = width - (calc_display_length(ljust_target) - ljust_target.length)
   ljust_target.ljust(adjusted_width)
-end
-
-def output_single_file(file_path, options)
-  if options[:l]
-    stat = File.stat(file_path)
-    details = convert_stat_to_details(stat)
-
-    DETAILS_KEYS.each do |key|
-      print "#{details[key]} "
-    end
-  end
-  puts file_path
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -13,23 +13,15 @@ RJUST_LIST = %i[nlink size].freeze
 
 def main
   options, paths = parse_options(ARGV)
-  # directory_pathsには複数のpathを指定することは許容しているが、現時点でファイル名を表示するのは1番目に指定したディレクトリのみにしている。
+  # pathsには複数のpathを指定することは許容しているが、ファイル名を表示するのは1番目に指定したディレクトリorファイルのみにしている。
   path = paths[0] || './'
-  # if File.file?(path)
-  #   puts path
-  # elsif File.directory?(path)
-  #   directory_path = path
-  #   file_names = fetch_file_names(directory_path, options)
-  #   output(file_names, directory_path, options)
-  # end
   if File.directory?(path)
     directory_path = path
     file_names = fetch_file_names(directory_path, options)
     output(file_names, directory_path, options)
   elsif File.file?(path)
-    file_names = [File.basename(path)]
-    directory_path = File.dirname(path)
-    file_name_specified_output(file_names, directory_path, options)
+    file_path = path
+    file_name_specified_output(file_path, options)
   end
 end
 
@@ -168,15 +160,16 @@ def ljust_include_multibyte_characters(ljust_target, width)
   ljust_target.ljust(adjusted_width)
 end
 
-def file_name_specified_output(file_names, directory_path, options)
-  file_name = file_names[0]
+def file_name_specified_output(file_path, options)
   if options[:l]
-    details_by_file_name = build_details_by_file_name(file_names, directory_path)
+    stat = File.stat(file_path)
+    details = convert_stat_to_details(stat)
+
     DETAILS_OUTPUT_ORDER.each do |key|
-      print "#{details_by_file_name[file_name][key]} "
+      print "#{details[key]} "
     end
   end
-  puts "#{directory_path}/#{file_name}"
+  puts file_path
 end
 
 main


### PR DESCRIPTION
[プラクティス ls コマンドを作る5](https://bootcamp.fjord.jp/practices/160)の課題として、lsコマンドに機能を追加しました。
終了条件は「[lsコマンドを作る4](https://github.com/cellotak/ruby-practices/pull/9)」の時点で終了条件は満たしていたので、追加で歓迎要件に対応しました。

## 終了条件
- -a -r -l オプションを全て使用できるlsコマンドを作って提出する。
- それぞれのオプションのスクリーンショットを貼る。
    - スクリーンショットは-a -l -r -al -alrオプションそれぞれの実行結果を貼ること
    - -alrでも-lraでも-ralでも順番に関係なく実行できる必要があります。
    - -ar -al -lr などオプションが2つの場合の組み合わせも自由に指定できるようにすること。
    
    
## 対応した歓迎要件
- 引数にファイルを指定可能にする(1つだけ)。
- 半角英数字以外のファイル名（ひらがなや漢字など）を持つファイルがあっても表示が崩れない。

## 対応できなかった要件
特にプラクティスページなどでは指定はされていませんが、複数ディレクトリや複数ファイル名の指定に対応していません。
対応しようとしたところ、全体を大幅に変更する必要があったため、オブジェクト指向版の課題として持ち越したいと考えています。
具体的には、これまでに作った多くのメソッドの引数が、 `(file_names, directory_path)` という形式で、第二引数が指定されたディレクトリのパス、第一引数がそのディレクトリに属するファイル名の配列としていましたが、ファイル名を複数指定した場合はディレクトリパスがそれぞれ異なっている場合があるため、既存メソッドをそのままは使えません。そのため既存メソッドを大幅に変更する必要があります。あくまでも「ディレクトリを指定する」という前提ですべて作ってしまい、変更に対応しづらい設計になってしまったので、作り直すのならオブジェクト指向版でやりたいと考えています。

下記メソッドなどが大幅に作り変える必要がある例
https://github.com/cellotak/ruby-practices/blob/bfd3d1bf8e30a2b057e9870fed718e4a474a43a0/04.ls/ls.rb#L49-L69

## 実行結果
#### オプション無し 
![image](https://github.com/cellotak/ruby-practices/assets/65953037/839dfe06-ccc9-4de6-8146-51d63e0d3634)

#### `-a`オプション
![image](https://github.com/cellotak/ruby-practices/assets/65953037/45adb94b-5e2d-4d74-8ff1-c767689753d1)

#### `-l`オプション
![image](https://github.com/cellotak/ruby-practices/assets/65953037/7ffbd85b-ea84-45f0-9edf-0097976f4e25)

#### `-al`オプション
![image](https://github.com/cellotak/ruby-practices/assets/65953037/d4d1a7fc-de8e-468f-8efc-7cb07dfa8963)

#### `-ar`, `-lr` (オプション2つで組み合わせが違うパターン)
![image](https://github.com/cellotak/ruby-practices/assets/65953037/458732da-fa41-4e72-bf13-f17e6280fb95)
![image](https://github.com/cellotak/ruby-practices/assets/65953037/0b805f7e-7c21-406b-ac7a-4282d7bff0bd)


#### `-alr`オプション
![image](https://github.com/cellotak/ruby-practices/assets/65953037/345eb7c0-0d96-4974-bfbc-333b91d51dfd)

#### `lra`, `-ral` (オプション3つで順番が違うパターン)
![image](https://github.com/cellotak/ruby-practices/assets/65953037/fa6144b9-b832-45cb-a06a-c1ba48d5d849)
![image](https://github.com/cellotak/ruby-practices/assets/65953037/a950e020-e37b-4bd3-8c8b-b29f73afca9a)


### 歓迎要件
#### ファイル名の指定
コマンド引数で指定できるのはディレクトリ名のみで、ファイル名を指定したときは何も出力しないようにしていましたが、本家の仕様に倣ってファイル名を指定したときは、そのファイルのファイルパスをそのまま表示するようにしました。ただし、本家とは違い、複数指定することはできない仕様です。

- 作成したlsコマンド
![image](https://github.com/cellotak/ruby-practices/assets/65953037/52f54ced-80bb-4f51-b2be-f1dd59001d69)

- OS標準lsコマンド
![image](https://github.com/cellotak/ruby-practices/assets/65953037/b6823c17-ee4a-498f-b585-f8971d199990)


#### 平仮名や漢字のファイル名の表示
平仮名や漢字のファイル名が含まれている場合、幅揃えが崩れる問題を解決しました。
![image](https://github.com/cellotak/ruby-practices/assets/65953037/a7f4f368-29e8-4b89-b271-e9ed9866663c)

