### PR TITLE
ls.rbのバグ修正

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -137,8 +137,8 @@ def output_default_format(file_names)
   row_count.times do |row_index|
     col_count.times do |col_index|
       # file_names_tableの行と列が逆で保存されているので、col_indexとrow_indexを入れ替えて出力させている
-      target_file_name = file_names_table[col_index][row_index]
-      print target_file_name&.ljust(widths[col_index])
+      target_file_name = file_names_table.dig(col_index, row_index)
+      print target_file_name&.ljust(widths[col_index]) if target_file_name
     end
     print "\n"
   end


### PR DESCRIPTION
出力対象が一つもないときにエラーが発生するバグを修正しました。

(cherry picked from commit dc7520fa37f6d57ec2facd49596ea803a98129c7)